### PR TITLE
Refactor database commit handling in multiple services

### DIFF
--- a/code/routers/station.py
+++ b/code/routers/station.py
@@ -388,8 +388,8 @@ async def create_station_status(
             message=status.message
         )
         db.add(db_status)
-        await db.commit()
-        await db.refresh(db_status)
+
+    await db.commit()
 
     return {"status": "success"}
 
@@ -437,8 +437,7 @@ async def create_station_data(
             location_id=db_station.location_id
         )
         db.add(db_measurement)
-        await db.commit()
-        await db.refresh(db_measurement)
+        await db.flush()
 
         for dimension, value in sensor_data.data.items():
             if station.calibration_mode:

--- a/code/services/data_service.py
+++ b/code/services/data_service.py
@@ -41,7 +41,6 @@ async def sensor_community_import_grouped_by_location(db: AsyncSession, data: di
 
         db.add(station)
         await db.commit()
-        await db.refresh(station)
 
         sensor_model = {v: k for k, v in SensorModel._names.items()}.get(row["sensor"]["sensor_type"]["name"], None)
 
@@ -63,8 +62,7 @@ async def sensor_community_import_grouped_by_location(db: AsyncSession, data: di
                 location_id=loc.id
             )
             db.add(measurement)
-            await db.commit()
-            await db.refresh(measurement)
+            await db.flush()
 
             for val in row['sensordatavalues']:
                 d = Dimension.get_dimension_from_sensor_community_name_import(val['value_type'])
@@ -168,8 +166,7 @@ async def import_station_data(db: AsyncSession, station_data, sensors):
             height=float(station_data['location']['height'])
         )
         db.add(new_location)
-        await db.commit()
-        await db.refresh(new_location)
+        await db.flush()
         logging.debug(f"Neue Location erstellt: {new_location}")
 
         db_station = Station(
@@ -182,7 +179,6 @@ async def import_station_data(db: AsyncSession, station_data, sensors):
         )
         db.add(db_station)
         await db.commit()
-        await db.refresh(db_station)
         logging.debug(f"Neue Station erstellt: {db_station}")
     else:
         logging.debug("Station existiert bereits, prüfe auf Aktualisierungen.")
@@ -244,8 +240,7 @@ async def import_station_data(db: AsyncSession, station_data, sensors):
             location_id=db_station.location_id
         )
         db.add(db_measurement)
-        await db.commit()
-        await db.refresh(db_measurement)
+        await db.flush()
         logging.debug(f"Neue Messung erstellt: {db_measurement}")
 
         for dimension, value in sensor_data['data'].items():

--- a/code/utils/geocoding.py
+++ b/code/utils/geocoding.py
@@ -86,7 +86,6 @@ async def get_or_create_location(db: AsyncSession, lat: float, lon: float, heigh
             country = Country(name=country_name, code=country_code)
             db.add(country)
             await db.commit()
-            await db.refresh(country)
             logging.debug(f"Neues Land erstellt: {country}")
         except Exception as e:
             logging.error(f"Fehler beim Erstellen des Landes '{country_name}': {e}")
@@ -105,7 +104,6 @@ async def get_or_create_location(db: AsyncSession, lat: float, lon: float, heigh
             city = City(name=city_name, country_id=country.id, tz=timezone_str, lat=clat, lon=clon)
             db.add(city)
             await db.commit()
-            await db.refresh(city)
             logging.debug(f"Neue Stadt erstellt: {city}")
 
             cache = get_cities_cache()
@@ -137,7 +135,6 @@ async def get_or_create_location(db: AsyncSession, lat: float, lon: float, heigh
             )
             db.add(location)
             await db.commit()
-            await db.refresh(location)
             logging.debug(f"Neue Location erstellt: {location}")
         except Exception as e:
             logging.error(f"Fehler beim Erstellen der Location: {e}")

--- a/code/utils/stations.py
+++ b/code/utils/stations.py
@@ -45,8 +45,7 @@ async def get_or_create_station(db: AsyncSession, station: StationDataCreate):
             height=float(station.location.height)
         )
         db.add(new_location)
-        await db.commit()
-        await db.refresh(new_location)
+        await db.flush()
 
         db_station = Station(
             device=station.device,
@@ -58,7 +57,6 @@ async def get_or_create_station(db: AsyncSession, station: StationDataCreate):
         )
         db.add(db_station)
         await db.commit()
-        await db.refresh(db_station)
     else:
         if db_station.apikey != station.apikey:
             raise HTTPException(


### PR DESCRIPTION
- Replaced `await db.commit()` with `await db.flush()` in various functions across `station.py`, `data_service.py`, `geocoding.py`, and `stations.py` to optimize database interactions.
- Removed unnecessary `await db.refresh()` calls after committing changes, streamlining the code and improving performance.