### PR TITLE
Enhance database handling for scheduler tasks

### DIFF
--- a/code/database.py
+++ b/code/database.py
@@ -3,6 +3,7 @@ import os
 from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import declarative_base
+from sqlalchemy.pool import NullPool
 
 # Umgebungsvariablen auslesen
 DB_USER = os.getenv("POSTGRES_USER", "")
@@ -17,6 +18,19 @@ ASYNC_DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg:/
 async_engine = create_async_engine(ASYNC_DATABASE_URL)
 AsyncSessionLocal = async_sessionmaker(
     async_engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+    autocommit=False,
+    autoflush=False,
+)
+
+# APScheduler runs asyncio.run() in worker threads; do not share the app pool across event loops.
+scheduler_async_engine = create_async_engine(
+    ASYNC_DATABASE_URL,
+    poolclass=NullPool,
+)
+SchedulerAsyncSessionLocal = async_sessionmaker(
+    scheduler_async_engine,
     class_=AsyncSession,
     expire_on_commit=False,
     autocommit=False,

--- a/code/main.py
+++ b/code/main.py
@@ -17,6 +17,8 @@ from apscheduler.schedulers.background import BackgroundScheduler
 import atexit
 from tasks.periodic_tasks import import_sensor_community_data, refresh_statistics_cache, refresh_stations_summary_cache
 
+from database import scheduler_async_engine
+
 import os
 import logging
 
@@ -154,6 +156,10 @@ def shutdown_scheduler():
         try:
             scheduler.shutdown()
         finally:
+            try:
+                scheduler_async_engine.sync_engine.dispose()
+            except Exception:
+                pass
             # Restore logger state (though this may not work if logging is already shut down)
             try:
                 scheduler_logger.setLevel(original_level)

--- a/code/monitoring/prometheus_metrics.py
+++ b/code/monitoring/prometheus_metrics.py
@@ -7,7 +7,6 @@ Default HTTP metrics still come from prometheus-fastapi-instrumentator; this mod
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Any, Optional
 
@@ -15,7 +14,7 @@ from prometheus_client import Counter, Gauge
 from prometheus_fastapi_instrumentator import metrics as instrumentator_metrics
 from sqlalchemy import text
 
-from database import async_engine
+from database import sync_engine
 
 logger = logging.getLogger(__name__)
 
@@ -89,12 +88,8 @@ def update_prometheus_app_gauges(app: Any, scheduler: Optional[Any] = None) -> N
         LUFTDATEN_SCHEDULER_JOBS.set(0)
 
     try:
-
-        async def _ping():
-            async with async_engine.connect() as conn:
-                await conn.execute(text("SELECT 1"))
-
-        asyncio.run(_ping())
+        with sync_engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
         LUFTDATEN_DB_UP.set(1)
     except Exception:
         LUFTDATEN_DB_UP.set(0)

--- a/code/tasks/periodic_tasks.py
+++ b/code/tasks/periodic_tasks.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import requests
-from database import AsyncSessionLocal
+from database import SchedulerAsyncSessionLocal
 from services.data_service import sensor_community_import_grouped_by_location
 from enums import Source
 from utils.cache import refresh_statistics_views, refresh_stations_summary
@@ -33,7 +33,7 @@ def import_sensor_community_data():
             return
 
         async def _run_import():
-            async with AsyncSessionLocal() as db:
+            async with SchedulerAsyncSessionLocal() as db:
                 await sensor_community_import_grouped_by_location(db, data, source=Source.SC)
 
         try:
@@ -52,7 +52,7 @@ def refresh_statistics_cache():
     logger.info("Task 'refresh_statistics_cache' started.")
 
     async def _run():
-        async with AsyncSessionLocal() as db:
+        async with SchedulerAsyncSessionLocal() as db:
             await refresh_statistics_views(db)
 
     try:
@@ -69,7 +69,7 @@ def refresh_stations_summary_cache():
     logger.info("Task 'refresh_stations_summary_cache' started.")
 
     async def _run():
-        async with AsyncSessionLocal() as db:
+        async with SchedulerAsyncSessionLocal() as db:
             await refresh_stations_summary(db)
 
     try:


### PR DESCRIPTION
- Introduced a new asynchronous database engine with NullPool for APScheduler to prevent sharing connections across event loops.
- Updated `main.py` to dispose of the scheduler's async engine during shutdown.
- Refactored periodic tasks to utilize the new `SchedulerAsyncSessionLocal` for database interactions, improving task execution reliability.
- Replaced async database calls with synchronous ones in Prometheus metrics to align with the new database structure.