### PR TITLE
Add shared memory size for Postgres and implement statistics snapshot…

### DIFF
--- a/code/alembic/versions/8d4c2b1a9f0e_add_statistics_endpoint_snapshot.py
+++ b/code/alembic/versions/8d4c2b1a9f0e_add_statistics_endpoint_snapshot.py
@@ -1,0 +1,258 @@
+"""Add statistics_endpoint_snapshot materialized view
+
+Single-row jsonb snapshot of /statistics payload, built from existing statistics MVs.
+Revision ID: 8d4c2b1a9f0e
+Revises: b3ba2ef0fc0, e2dda8ce7cd2 (merge)
+Create Date: 2026-04-10
+
+"""
+from typing import Sequence, Union, Tuple
+
+from alembic import op
+
+revision: str = "8d4c2b1a9f0e"
+down_revision: Union[str, Tuple[str, ...], None] = ("b3ba2ef0fc0", "e2dda8ce7cd2")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Enum label maps kept in sync with code/enums.py (Source, SensorModel, Dimension)
+_SNAPSHOT_SELECT = r"""
+CREATE MATERIALIZED VIEW statistics_endpoint_snapshot AS
+SELECT
+    1 AS id,
+    jsonb_build_object(
+        'totals', jsonb_build_object(
+            'countries', (SELECT total_countries FROM statistics_summary ORDER BY last_refresh DESC NULLS LAST LIMIT 1),
+            'cities', (SELECT total_cities FROM statistics_summary ORDER BY last_refresh DESC NULLS LAST LIMIT 1),
+            'locations', (SELECT total_locations FROM statistics_summary ORDER BY last_refresh DESC NULLS LAST LIMIT 1),
+            'stations', (SELECT total_stations FROM statistics_summary ORDER BY last_refresh DESC NULLS LAST LIMIT 1),
+            'measurements', (SELECT total_measurements FROM statistics_summary ORDER BY last_refresh DESC NULLS LAST LIMIT 1),
+            'calibration_measurements', (SELECT total_calibration_measurements FROM statistics_summary ORDER BY last_refresh DESC NULLS LAST LIMIT 1),
+            'values', (SELECT total_values FROM statistics_summary ORDER BY last_refresh DESC NULLS LAST LIMIT 1),
+            'station_statuses', (SELECT total_station_statuses FROM statistics_summary ORDER BY last_refresh DESC NULLS LAST LIMIT 1)
+        ),
+        'active_stations', jsonb_build_object(
+            'last_hour', COALESCE((SELECT last_hour FROM active_stations_summary ORDER BY last_refresh DESC NULLS LAST LIMIT 1), 0),
+            'last_24_hours', COALESCE((SELECT last_24_hours FROM active_stations_summary ORDER BY last_refresh DESC NULLS LAST LIMIT 1), 0),
+            'last_7_days', COALESCE((SELECT last_7_days FROM active_stations_summary ORDER BY last_refresh DESC NULLS LAST LIMIT 1), 0),
+            'last_30_days', COALESCE((SELECT last_30_days FROM active_stations_summary ORDER BY last_refresh DESC NULLS LAST LIMIT 1), 0)
+        ),
+        'data_coverage', jsonb_build_object(
+            'earliest_measurement', to_jsonb((SELECT earliest_measurement FROM statistics_summary ORDER BY last_refresh DESC NULLS LAST LIMIT 1)),
+            'latest_measurement', to_jsonb((SELECT latest_measurement FROM statistics_summary ORDER BY last_refresh DESC NULLS LAST LIMIT 1)),
+            'measurements_last_24h', COALESCE((SELECT last_24h FROM measurements_timeframe_summary ORDER BY last_refresh DESC NULLS LAST LIMIT 1), 0),
+            'measurements_last_7d', COALESCE((SELECT last_7d FROM measurements_timeframe_summary ORDER BY last_refresh DESC NULLS LAST LIMIT 1), 0),
+            'measurements_last_30d', COALESCE((SELECT last_30d FROM measurements_timeframe_summary ORDER BY last_refresh DESC NULLS LAST LIMIT 1), 0)
+        ),
+        'distribution', jsonb_build_object(
+            'stations_by_source', COALESCE((
+                SELECT jsonb_object_agg(src_label, cnt)
+                FROM (
+                    SELECT
+                        CASE source
+                            WHEN 1 THEN 'Luftdaten.at'
+                            WHEN 2 THEN 'Luftdaten.at TTN LoRaWAN'
+                            WHEN 3 THEN 'sensor.community'
+                            ELSE 'Unknown'
+                        END AS src_label,
+                        count AS cnt
+                    FROM stations_by_source_summary
+                    WHERE count > 0
+                ) sbs
+            ), '{}'::jsonb),
+            'stations_by_country', COALESCE((
+                SELECT jsonb_object_agg(country_name, station_count)
+                FROM stations_by_country_summary
+            ), '{}'::jsonb),
+            'top_cities', COALESCE((
+                SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'city', city_name,
+                        'country', country_name,
+                        'station_count', station_count
+                    )
+                    ORDER BY station_count DESC
+                )
+                FROM top_cities_summary
+            ), '[]'::jsonb),
+            'sensor_models', COALESCE((
+                SELECT jsonb_object_agg(
+                    CASE sensor_model
+                        WHEN 1 THEN 'SEN5X'
+                        WHEN 2 THEN 'BMP280'
+                        WHEN 3 THEN 'BME280'
+                        WHEN 4 THEN 'BME680'
+                        WHEN 5 THEN 'SCD4X'
+                        WHEN 6 THEN 'AHT20'
+                        WHEN 7 THEN 'SHT30'
+                        WHEN 8 THEN 'SHT31'
+                        WHEN 9 THEN 'AGS02MA'
+                        WHEN 10 THEN 'SHT4X'
+                        WHEN 11 THEN 'SGP40'
+                        WHEN 12 THEN 'DHT22'
+                        WHEN 13 THEN 'SDS011'
+                        WHEN 14 THEN 'SHT35'
+                        WHEN 15 THEN 'SPS30'
+                        WHEN 16 THEN 'PMS5003'
+                        WHEN 17 THEN 'PMS7003'
+                        ELSE 'Unknown Sensor'
+                    END,
+                    count
+                )
+                FROM sensor_models_summary
+                WHERE count > 0
+            ), '{}'::jsonb),
+            'calibration_sensors', COALESCE((
+                SELECT jsonb_object_agg(
+                    CASE sensor_model
+                        WHEN 1 THEN 'SEN5X'
+                        WHEN 2 THEN 'BMP280'
+                        WHEN 3 THEN 'BME280'
+                        WHEN 4 THEN 'BME680'
+                        WHEN 5 THEN 'SCD4X'
+                        WHEN 6 THEN 'AHT20'
+                        WHEN 7 THEN 'SHT30'
+                        WHEN 8 THEN 'SHT31'
+                        WHEN 9 THEN 'AGS02MA'
+                        WHEN 10 THEN 'SHT4X'
+                        WHEN 11 THEN 'SGP40'
+                        WHEN 12 THEN 'DHT22'
+                        WHEN 13 THEN 'SDS011'
+                        WHEN 14 THEN 'SHT35'
+                        WHEN 15 THEN 'SPS30'
+                        WHEN 16 THEN 'PMS5003'
+                        WHEN 17 THEN 'PMS7003'
+                        ELSE 'Unknown Sensor'
+                    END,
+                    count
+                )
+                FROM calibration_sensors_summary
+                WHERE count > 0
+            ), '{}'::jsonb),
+            'status_by_level', COALESCE((
+                SELECT jsonb_object_agg('level_' || level::text, count)
+                FROM status_by_level_summary
+            ), '{}'::jsonb)
+        ),
+        'dimensions', COALESCE((
+            SELECT jsonb_agg(obj ORDER BY ord DESC)
+            FROM (
+                SELECT
+                    value_count AS ord,
+                    jsonb_build_object(
+                        'dimension_id', dimension,
+                        'dimension_name', CASE dimension
+                            WHEN 1 THEN 'PM0.1'
+                            WHEN 2 THEN 'PM1.0'
+                            WHEN 3 THEN 'PM2.5'
+                            WHEN 4 THEN 'PM4.0'
+                            WHEN 5 THEN 'PM10.0'
+                            WHEN 6 THEN 'Humidity'
+                            WHEN 7 THEN 'Temperature'
+                            WHEN 8 THEN 'VOC Index'
+                            WHEN 9 THEN 'NOx Index'
+                            WHEN 10 THEN 'Pressure'
+                            WHEN 11 THEN 'CO2'
+                            WHEN 12 THEN 'Ozone (O3)'
+                            WHEN 13 THEN 'Air Quality Index (AQI)'
+                            WHEN 14 THEN 'Gas Resistance'
+                            WHEN 15 THEN 'Total VOC'
+                            WHEN 16 THEN 'Nitrogen Dioxide (NO2)'
+                            WHEN 17 THEN 'SGP40 Raw Gas'
+                            WHEN 18 THEN 'SGP40 Adjusted Gas'
+                            ELSE 'Unknown'
+                        END,
+                        'unit', CASE dimension
+                            WHEN 1 THEN 'µg/m³'
+                            WHEN 2 THEN 'µg/m³'
+                            WHEN 3 THEN 'µg/m³'
+                            WHEN 4 THEN 'µg/m³'
+                            WHEN 5 THEN 'µg/m³'
+                            WHEN 6 THEN '%'
+                            WHEN 7 THEN '°C'
+                            WHEN 8 THEN 'Index'
+                            WHEN 9 THEN 'Index'
+                            WHEN 10 THEN 'hPa'
+                            WHEN 11 THEN 'ppm'
+                            WHEN 12 THEN 'ppb'
+                            WHEN 13 THEN 'Index'
+                            WHEN 14 THEN 'Ω'
+                            WHEN 15 THEN 'ppb'
+                            WHEN 16 THEN 'ppb'
+                            WHEN 17 THEN 'Ω'
+                            WHEN 18 THEN 'Ω'
+                            ELSE 'Unknown'
+                        END,
+                        'value_count', value_count,
+                        'average_value', CASE
+                            WHEN avg_value IS NULL OR avg_value != avg_value THEN NULL
+                            ELSE to_jsonb(avg_value::double precision)
+                        END,
+                        'min_value', CASE
+                            WHEN min_value IS NULL OR min_value != min_value THEN NULL
+                            ELSE to_jsonb(min_value::double precision)
+                        END,
+                        'max_value', CASE
+                            WHEN max_value IS NULL OR max_value != max_value THEN NULL
+                            ELSE to_jsonb(max_value::double precision)
+                        END
+                    ) AS obj
+                FROM dimension_statistics_summary
+            ) dimsub
+        ), '[]'::jsonb)
+    ) AS payload
+"""
+
+
+_REFRESH_FN_BODY = r"""
+CREATE OR REPLACE FUNCTION refresh_statistics_views()
+RETURNS void AS $$
+BEGIN
+    REFRESH MATERIALIZED VIEW CONCURRENTLY statistics_summary;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY active_stations_summary;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY stations_by_country_summary;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY top_cities_summary;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY dimension_statistics_summary;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY sensor_models_summary;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY calibration_sensors_summary;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY status_by_level_summary;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY stations_by_source_summary;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY measurements_timeframe_summary;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY statistics_endpoint_snapshot;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+_REFRESH_FN_PRE_SNAPSHOT = r"""
+CREATE OR REPLACE FUNCTION refresh_statistics_views()
+RETURNS void AS $$
+BEGIN
+    REFRESH MATERIALIZED VIEW CONCURRENTLY statistics_summary;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY active_stations_summary;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY stations_by_country_summary;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY top_cities_summary;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY dimension_statistics_summary;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY sensor_models_summary;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY calibration_sensors_summary;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY status_by_level_summary;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY stations_by_source_summary;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY measurements_timeframe_summary;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+def upgrade() -> None:
+    op.execute(_SNAPSHOT_SELECT.strip())
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_statistics_endpoint_snapshot_id "
+        "ON statistics_endpoint_snapshot (id)"
+    )
+    op.execute(_REFRESH_FN_BODY.strip())
+
+
+def downgrade() -> None:
+    op.execute(_REFRESH_FN_PRE_SNAPSHOT.strip())
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS statistics_endpoint_snapshot CASCADE")

--- a/code/routers/statistics.py
+++ b/code/routers/statistics.py
@@ -5,6 +5,10 @@ from database import get_db
 from utils.helpers import as_naive_utc
 from dependencies import get_blacklist
 from datetime import datetime, timezone, timedelta
+from typing import Optional
+from starlette.responses import JSONResponse
+import hashlib
+import json
 import math
 from models import (
     Country, City, Location, Station, Measurement,
@@ -13,6 +17,45 @@ from models import (
 from enums import Source, SensorModel, Dimension
 
 router = APIRouter()
+
+_STATISTICS_CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=120"
+
+
+def _statistics_snapshot_response(payload: object, now: datetime) -> JSONResponse:
+    """Build HTTP response from precomputed jsonb snapshot; timestamp reflects request time."""
+    if isinstance(payload, str):
+        data = json.loads(payload)
+    else:
+        data = json.loads(json.dumps(payload, default=str))
+    out = dict(data)
+    out["timestamp"] = now.isoformat()
+    body_etag = {k: v for k, v in out.items() if k != "timestamp"}
+    etag_val = hashlib.md5(
+        json.dumps(body_etag, sort_keys=True, default=str).encode()
+    ).hexdigest()
+    return JSONResponse(
+        content=out,
+        headers={
+            "Cache-Control": _STATISTICS_CACHE_CONTROL,
+            "ETag": f'W/"{etag_val}"',
+        },
+    )
+
+
+async def _try_load_statistics_snapshot(
+    db: AsyncSession, now: datetime
+) -> Optional[JSONResponse]:
+    try:
+        res = await db.execute(
+            text("SELECT payload FROM statistics_endpoint_snapshot WHERE id = 1")
+        )
+        row = res.first()
+        if row is None or row.payload is None:
+            return None
+        return _statistics_snapshot_response(row.payload, now)
+    except Exception:
+        await db.rollback()
+        return None
 
 
 @router.get("/", tags=["statistics"])
@@ -25,6 +68,11 @@ async def get_statistics(
     one_day_ago = as_naive_utc(now - timedelta(days=1))
     seven_days_ago = as_naive_utc(now - timedelta(days=7))
     thirty_days_ago = as_naive_utc(now - timedelta(days=30))
+
+    if not blacklist:
+        snap = await _try_load_statistics_snapshot(db, now)
+        if snap is not None:
+            return snap
 
     use_materialized_views = not bool(blacklist)
 

--- a/code/tests/test_statistics.py
+++ b/code/tests/test_statistics.py
@@ -3,9 +3,12 @@ import os
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+import json
+
 import pytest
 from fastapi.testclient import TestClient
 from main import app
+from routers.statistics import _statistics_snapshot_response
 from models import (
     City, Country, Station, Location, Measurement, Values,
     CalibrationMeasurement, StationStatus
@@ -449,4 +452,40 @@ class TestStatisticsRouter:
         parsed_time = datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
         now = datetime.now(timezone.utc)
         assert abs((now - parsed_time).total_seconds()) < 60
+
+
+class TestStatisticsSnapshotHelpers:
+    """Precomputed jsonb snapshot response (used when statistics_endpoint_snapshot exists)."""
+
+    def test_statistics_snapshot_response_sets_timestamp_and_http_cache_headers(self):
+        fixed_now = datetime(2026, 4, 10, 12, 0, 0, tzinfo=timezone.utc)
+        payload = {
+            "totals": {"countries": 1},
+            "active_stations": {"last_hour": 0, "last_24_hours": 0, "last_7_days": 0, "last_30_days": 0},
+            "data_coverage": {},
+            "distribution": {},
+            "dimensions": [],
+        }
+        resp = _statistics_snapshot_response(payload, fixed_now)
+        assert resp.status_code == 200
+        body = json.loads(resp.body)
+        assert body["timestamp"] == fixed_now.isoformat()
+        assert "public" in resp.headers.get("cache-control", "")
+        assert "max-age=3600" in resp.headers.get("cache-control", "")
+        assert resp.headers.get("etag", "").startswith('W/"')
+
+    def test_statistics_snapshot_response_accepts_json_string_payload(self):
+        now = datetime.now(timezone.utc)
+        payload = json.dumps(
+            {
+                "totals": {},
+                "active_stations": {},
+                "data_coverage": {},
+                "distribution": {},
+                "dimensions": [],
+            }
+        )
+        resp = _statistics_snapshot_response(payload, now)
+        body = json.loads(resp.body)
+        assert "timestamp" in body
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       start_period: 40s
   db:
     image: postgres:16
+    # Default 64MB /dev/shm is too small for Postgres under load (avoids DiskFullError on shm resize)
+    shm_size: "256mb"
     ports:
      - "5432:5432"
     volumes:

--- a/example-docker-compose.prod.yml
+++ b/example-docker-compose.prod.yml
@@ -30,6 +30,8 @@ services:
       start_period: 40s
   db:
     image: postgres:16
+    # Default 64MB /dev/shm is too small for Postgres under load (avoids DiskFullError on shm resize)
+    shm_size: "256mb"
     networks:
       - default
     volumes:


### PR DESCRIPTION
… view

- Increased shared memory size to 256MB in `docker-compose.yml` and `example-docker-compose.prod.yml` to prevent DiskFullError under load.
- Added a new Alembic migration script to create a materialized view `statistics_endpoint_snapshot` for optimized statistics retrieval.
- Enhanced the statistics router to utilize the new snapshot, improving response times and caching with appropriate HTTP headers.
- Added tests for the new snapshot response functionality to ensure correct timestamp and cache control headers.