### PR TITLE
Add localhost to CORS allowlist in `_cors_allowlist()` function

### DIFF
--- a/code/main.py
+++ b/code/main.py
@@ -61,6 +61,7 @@ def _cors_allowlist():
             "http://127.0.0.1:3000",
             "http://localhost:5173",
             "http://127.0.0.1:5173",
+            "http://localhost",
         ],
         True,
     )


### PR DESCRIPTION
- Updated the CORS allowlist in `main.py` to include "http://localhost" for improved local development support.