### PR TITLE
Enhance PostgreSQL monitoring and diagnostics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,12 @@ DB_HOST=db
 # DB_POOL_SIZE=20
 # DB_MAX_OVERFLOW=40
 
+# libpq / asyncpg application_name (visible in pg_stat_activity; default luftdaten-api)
+# POSTGRES_APPLICATION_NAME=luftdaten-api
+
+# Log every emitted SQL line to stderr (dev only; very noisy)
+# DB_SQL_ECHO=true
+
 # -----------------------------------------------------------------------------
 # App (optional)
 # -----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ Stations can be excluded from API responses via a blacklist config file. Blackli
 - Grafana panels filter metrics with `job="<name>"`. The **Luftdaten API** dashboard exposes **API Prometheus job** (from `label_values(http_requests_total, job)`); pick the value that matches your scrape config’s `job_name` (default in repo: `luftdaten-api`). If panels show *No data*, check **Status → Targets** in Prometheus and run `http_requests_total` in **Graph** to see the real `job` label. The app must register **`metrics.default()`** alongside the custom `luftdaten_*` instrumentation (see [`code/main.py`](code/main.py)); otherwise `http_requests_total` and latency histograms are never emitted and Grafana stays empty regardless of `job`.
 - **`handler="none"`** for most traffic: prometheus-fastapi-instrumentator resolves the route **before** inner middleware runs. `/v1/...` must be stripped **outside** that middleware (see `VersionPrefixMiddleware` in [`code/main.py`](code/main.py)); otherwise routes registered as `/station/...` never match and Grafana shows `none` instead of `/station/current`, etc.
 
+**PostgreSQL query diagnostics (slow SQL / index hints):**
+- The `db` service loads **`pg_stat_statements`** via `shared_preload_libraries` (see `docker-compose.yml`). After pulling the change, **restart Postgres** (or recreate the volume) so the setting applies, then run **`alembic upgrade head`** — migration **`7f3a9c2e1d0b`** runs `CREATE EXTENSION IF NOT EXISTS pg_stat_statements`.
+- Existing data directories that were created **without** this `command` need a one-time restart of the `db` container after the compose update; if `CREATE EXTENSION` still errors, ensure `shared_preload_libraries` is active (`SHOW shared_preload_libraries;` in `psql`).
+- **`postgres_exporter`** (monitoring profile) enables **`--collector.stat_statements`** and **`--collector.statio_user_indexes`** with a 40-statement cap. Grafana dashboard **Luftdaten API** adds panels for cumulative time by `queryid`, seq scans by table, time rate, and index block read rate (`job="postgres"`).
+- Map a **`queryid`** back to SQL in `psql`: `SELECT query FROM pg_stat_statements WHERE queryid = <value>;` (large cardinality — do not enable `--collector.stat_statements.include_query` on busy servers without care).
+- App connections set **`application_name`** (override with `POSTGRES_APPLICATION_NAME`). Optional dev-only SQL logging: **`DB_SQL_ECHO=true`** (see `.env.example`).
+
 #### Deployment
 
 Build and push to Dockerhub.

--- a/code/alembic/versions/7f3a9c2e1d0b_enable_pg_stat_statements.py
+++ b/code/alembic/versions/7f3a9c2e1d0b_enable_pg_stat_statements.py
@@ -1,0 +1,29 @@
+"""Enable pg_stat_statements extension for query statistics.
+
+Requires PostgreSQL to load the library at startup, e.g.:
+  shared_preload_libraries = 'pg_stat_statements'
+(see docker-compose `db` service `command`).
+
+Revision ID: 7f3a9c2e1d0b
+Revises: 8d4c2b1a9f0e
+Create Date: 2026-04-10
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "7f3a9c2e1d0b"
+down_revision: Union[str, None] = "8d4c2b1a9f0e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(sa.text("CREATE EXTENSION IF NOT EXISTS pg_stat_statements"))
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DROP EXTENSION IF EXISTS pg_stat_statements"))

--- a/code/database.py
+++ b/code/database.py
@@ -17,6 +17,13 @@ DB_NAME = os.getenv("POSTGRES_DB", "")
 DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASS}@{DB_HOST}/{DB_NAME}"
 ASYNC_DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
 
+_POSTGRES_APP_NAME = os.getenv("POSTGRES_APPLICATION_NAME", "luftdaten-api")
+_async_connect_args = {
+    "server_settings": {"application_name": _POSTGRES_APP_NAME},
+}
+_sync_connect_args = {"application_name": _POSTGRES_APP_NAME}
+_sqlalchemy_echo = os.getenv("DB_SQL_ECHO", "").lower() in ("1", "true", "yes")
+
 # region agent log
 def _agent_log(
     hypothesis_id: str,
@@ -74,6 +81,8 @@ async_engine = create_async_engine(
     max_overflow=_max_overflow,
     pool_timeout=60,
     pool_pre_ping=True,
+    echo=_sqlalchemy_echo,
+    connect_args=_async_connect_args,
 )
 AsyncSessionLocal = async_sessionmaker(
     async_engine,
@@ -87,6 +96,11 @@ AsyncSessionLocal = async_sessionmaker(
 scheduler_async_engine = create_async_engine(
     ASYNC_DATABASE_URL,
     poolclass=NullPool,
+    connect_args={
+        "server_settings": {
+            "application_name": f"{_POSTGRES_APP_NAME}-scheduler",
+        },
+    },
 )
 SchedulerAsyncSessionLocal = async_sessionmaker(
     scheduler_async_engine,
@@ -97,7 +111,10 @@ SchedulerAsyncSessionLocal = async_sessionmaker(
 )
 
 # Sync engine for Alembic / scripts that still use synchronous SQLAlchemy
-sync_engine = create_engine(DATABASE_URL)
+sync_engine = create_engine(
+    DATABASE_URL,
+    connect_args={**_sync_connect_args, "application_name": f"{_POSTGRES_APP_NAME}-alembic"},
+)
 
 Base = declarative_base()
 

--- a/code/db_testing.py
+++ b/code/db_testing.py
@@ -8,10 +8,15 @@ from sqlalchemy.pool import NullPool
 SYNC_URL = "postgresql://test_user:test_password@db_test/test_database"
 ASYNC_URL = SYNC_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
 
-test_sync_engine = create_engine(SYNC_URL, poolclass=NullPool)
+_test_connect = {"application_name": "luftdaten-api-test"}
+_test_async_connect = {"server_settings": {"application_name": "luftdaten-api-test"}}
+
+test_sync_engine = create_engine(SYNC_URL, poolclass=NullPool, connect_args=_test_connect)
 TestSyncSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=test_sync_engine)
 
-test_async_engine = create_async_engine(ASYNC_URL, poolclass=NullPool)
+test_async_engine = create_async_engine(
+    ASYNC_URL, poolclass=NullPool, connect_args=_test_async_connect
+)
 TestAsyncSessionLocal = async_sessionmaker(
     test_async_engine,
     class_=AsyncSession,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,13 @@ services:
     image: postgres:16
     # Default 64MB /dev/shm is too small for Postgres under load (avoids DiskFullError on shm resize)
     shm_size: "256mb"
+    # pg_stat_statements (see Alembic 7f3a9c2e1d0b); track_io_timing helps blk_*_time in pg_stat_statements
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_preload_libraries=pg_stat_statements"
+      - "-c"
+      - "track_io_timing=on"
     ports:
      - "5432:5432"
     volumes:
@@ -39,6 +46,12 @@ services:
       start_period: 10s
   db_test:
     image: postgres:16
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_preload_libraries=pg_stat_statements"
+      - "-c"
+      - "track_io_timing=on"
     ports:
       - "5433:5432"
     environment:
@@ -77,6 +90,10 @@ services:
     profiles:
       - monitoring
     image: prometheuscommunity/postgres-exporter:latest
+    command:
+      - "--collector.stat_statements"
+      - "--collector.stat_statements.limit=40"
+      - "--collector.statio_user_indexes"
     environment:
       # DATA_SOURCE_URI must be host:port/db?params only (no postgresql://, no user:pass).
       # See https://github.com/prometheus-community/postgres_exporter#environment-variables

--- a/example-docker-compose.prod.yml
+++ b/example-docker-compose.prod.yml
@@ -32,6 +32,12 @@ services:
     image: postgres:16
     # Default 64MB /dev/shm is too small for Postgres under load (avoids DiskFullError on shm resize)
     shm_size: "256mb"
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_preload_libraries=pg_stat_statements"
+      - "-c"
+      - "track_io_timing=on"
     networks:
       - default
     volumes:
@@ -75,6 +81,10 @@ services:
       - monitoring
     image: prometheuscommunity/postgres-exporter:latest
     restart: unless-stopped
+    command:
+      - "--collector.stat_statements"
+      - "--collector.stat_statements.limit=40"
+      - "--collector.statio_user_indexes"
     environment:
       # DATA_SOURCE_URI must be host:port/db?params only (no postgresql://, no user:pass).
       DATA_SOURCE_URI: db:5432/${POSTGRES_DB:-postgres}?sslmode=disable

--- a/monitoring/grafana/dashboards/luftdaten-api.json
+++ b/monitoring/grafana/dashboards/luftdaten-api.json
@@ -405,6 +405,168 @@
       ],
       "title": "Postgres xact commit rate (if postgres job enabled)",
       "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Cumulative time from pg_stat_statements (resets on stats reset). Map queryid to SQL in psql: SELECT query FROM pg_stat_statements WHERE queryid = <id>::bigint;",
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" } },
+          "decimals": 3,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 63 },
+      "id": 15,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "Value" }]
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "topk(25, max by (datname, user, queryid) (pg_stat_statements_seconds_total{job=\"postgres\"}))",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Postgres: top statements by cumulative time (queryid)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true },
+            "renameByName": {
+              "datname": "Database",
+              "user": "Role",
+              "queryid": "queryid",
+              "Value": "Total time (s)"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "High seq_scan on large tables can indicate missing indexes (heuristic — confirm with EXPLAIN ANALYZE).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" } },
+          "decimals": 0,
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 63 },
+      "id": 16,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "Value" }]
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "topk(25, max by (datname, schemaname, relname) (pg_stat_user_tables_seq_scan{job=\"postgres\"}))",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Postgres: sequential scans by table (seq_scan counter)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true },
+            "renameByName": {
+              "datname": "Database",
+              "schemaname": "Schema",
+              "relname": "Table",
+              "Value": "seq_scan"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "none" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 73 },
+      "id": 17,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "topk(10, sum by (queryid) (rate(pg_stat_statements_seconds_total{job=\"postgres\"}[5m])))",
+          "legendFormat": "queryid {{queryid}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Postgres: statement DB time rate by queryid (top 10)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Disk reads via indexes (pg_statio_user_indexes). High rates may warrant EXPLAIN or index tuning.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" } },
+          "decimals": 4,
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 81 },
+      "id": 18,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "idx read/s" }]
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "topk(20, sum by (schemaname, relname, indexrelname) (rate(pg_statio_user_indexes_idx_blks_read_total{job=\"postgres\"}[5m])))",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Postgres: index block read rate (top 20)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true },
+            "renameByName": {
+              "schemaname": "Schema",
+              "relname": "Table",
+              "indexrelname": "Index",
+              "Value": "idx read/s"
+            }
+          }
+        }
+      ],
+      "type": "table"
     }
   ],
   "refresh": "30s",
@@ -436,6 +598,6 @@
   "timezone": "",
   "title": "Luftdaten API",
   "uid": "luftdaten-api",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }


### PR DESCRIPTION
- Added support for `pg_stat_statements` in the PostgreSQL configuration to track query statistics.
- Updated Docker Compose files to include necessary commands for enabling `pg_stat_statements` and `track_io_timing`.
- Enhanced the README with instructions on using `pg_stat_statements` for query diagnostics and logging.
- Updated Grafana dashboards to visualize cumulative query time and sequential scans, aiding in performance monitoring.
- Introduced new environment variables for application name and SQL logging in the database connection settings.